### PR TITLE
devolución de Code 201 y número ID del alumno creado (POST)

### DIFF
--- a/Controllers/AlumnosController.cs
+++ b/Controllers/AlumnosController.cs
@@ -73,7 +73,7 @@ namespace PAII_TP_Final.Controllers
 
             if (createdAlumno != null)
             {
-                return CreatedAtAction("GetStudentByIdAsync", new { id = createdAlumno.Id }, createdAlumno);
+                return StatusCode(201, new { id = createdAlumno.Id });
             }
             else
             {


### PR DESCRIPTION
se reemplaza "CreatedAtAction" en el método POST para devolver directamente el ID del alumno creado con un código de estado 201 (Created). Esto se hizo para evitar un error 500 y proporcionar al cliente una respuesta más directa y legible.